### PR TITLE
feat(Tag): allow whitespaces from both ends

### DIFF
--- a/src/WrapperCreatorModal.ts
+++ b/src/WrapperCreatorModal.ts
@@ -45,7 +45,7 @@ export default class WrapperCreatorModal extends Modal {
 			.addText(cb => {
 				cb.setValue(this.wrapper.startTag ?? "")
 					.onChange(value => {
-						this.wrapper.startTag = value.trim();
+						this.wrapper.startTag = value;
 					})
 			})
 
@@ -55,7 +55,7 @@ export default class WrapperCreatorModal extends Modal {
 			.addText(cb => {
 				cb.setValue(this.wrapper.endTag ?? "")
 					.onChange(value => {
-						this.wrapper.endTag = value.trim();
+						this.wrapper.endTag = value;
 					})
 			})
 


### PR DESCRIPTION
Fix #4 

## WHY
To allow to create a wrapper like this:

Example: Add todo list
Start Tag: "`- [ ] `"
End Tag: "` #todo`"